### PR TITLE
Fix Several Map Bugs Part 1

### DIFF
--- a/map/games/Red_Sun_Over_China.xml
+++ b/map/games/Red_Sun_Over_China.xml
@@ -1799,10 +1799,6 @@
       <option name="attack" value="0"/>
       <option name="defense" value="0"/>
     </attachment>
-    <!-- colonial_outpost
-                <attachment name="unitAttachment" attachTo="colonial_outpost" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
-                         <option name="isFactory" value="true"/>
-                </attachment> -->
     <!-- Factory -->
     <attachment name="unitAttachment" attachTo="factory" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
       <option name="attack" value="0"/>
@@ -1814,6 +1810,7 @@
       <option name="attack" value="0"/>
       <option name="defense" value="0"/>
       <option name="isFactory" value="true"/>
+      <option name="canBeDamaged" value="false"/>
     </attachment>
     <!-- AA Gun -->
     <attachment name="unitAttachment" attachTo="aaGun" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">

--- a/map/games/Red_Sun_Over_China.xml
+++ b/map/games/Red_Sun_Over_China.xml
@@ -3591,6 +3591,7 @@
     </resourceInitialize>
   </initialize>
   <propertyList>
+  
     <!-- Bidding -->
     <property name="Nationalist bid" value="0" editable="true">
       <number min="0" max="1000"/>
@@ -3610,21 +3611,8 @@
     <property name="British bid" value="0" editable="true">
       <number min="0" max="1000"/>
     </property>
+    
     <!-- OPTIONAL PROPERTIES -->
-    <!-- victory options -->
-    <!--
-				<property name="Projection of Power" value="false" editable="true">
-                        <boolean/>
-                </property> 
-                
-                <property name="Honorable Surrender" value="true" editable="true">
-                        <boolean/>
-                </property>
-                
-				<property name="Total Victory" value="false" editable="true">
-                        <boolean/>
-                </property>
-                -->
     <property name="Low Luck" value="true" editable="true">
       <boolean/>
     </property>
@@ -3640,36 +3628,20 @@
     <property name="National Objectives" value="true" editable="true">
       <boolean/>
     </property>
-    <!--
-                <property name="Tech Development" value="true" editable="true">
-                	<boolean/>
-                </property>
-
-				<property name="Super Sub Defence Bonus" value="0" editable="true">
-						<number min="0" max="1"/>
-				</property>
-				
-				<property name="LHTR Heavy Bombers" value="false" editable="true">
-                	  <boolean/>
-                </property>
-                
-				<property name="Heavy Bomber Dice Rolls" value="2" editable="true">
-                        <number min="2" max="3"/>
-                </property>
-				-->
     <property name="Always on AA" value="true" editable="true">
       <boolean/>
     </property>
     <property name="Kamikaze Airplanes" value="true" editable="true">
       <boolean/>
     </property>
-    <property name="Battleships repair at end of round" value="true" editable="true">
+    <property name="Units Repair Hits End Turn" value="true" editable="true">
       <boolean/>
     </property>
-    <property name="Battleships repair at beginning of round" value="false" editable="true">
+    <property name="Units Repair Hits Start Turn" value="false" editable="true">
       <boolean/>
     </property>
     <!-- END OF OPTIONAL PROPERTIES -->
+    
     <!-- rules and tech -->
     <property name="WW2V3" value="true" editable="false">
       <boolean/>
@@ -3677,19 +3649,7 @@
     <property name="WW2V3 Tech Model" value="true" editable="false">
       <boolean/>
     </property>
-    <!--
-                <property name="Use Shipyards" value="false" editable="false">
-                        <boolean/>
-                </property>
-                
-				<property name="All Rockets Attack" value="true" editable="false">
-                        <boolean/>
-                </property>
-                
-				<property name="Rockets Can Fly Over Impassables" value="false" editable="false">
-                        <boolean/>
-                </property>
-				-->
+
     <!-- These require an associated value in the attachments section above-->
     <property name="Movement By Territory Restricted" value="true" editable="false">
       <boolean/>
@@ -3721,6 +3681,7 @@
     <property name="AA Territory Restricted" value="false" editable="false">
       <boolean/>
     </property>
+    
     <!-- sea related -->
     <property name="Partial Amphibious Retreat" value="true" editable="false">
       <boolean/>
@@ -3773,6 +3734,7 @@
     <property name="Two hit battleship" value="true" editable="false">
       <boolean/>
     </property>
+    
     <!-- production related -->
     <property name="Produce fighters on carriers" value="true" editable="false">
       <boolean/>
@@ -3802,6 +3764,7 @@
     <property name="Damage From Bombing Done To Units Instead Of Territories" value="true" editable="false">
       <boolean/>
     </property>
+    
     <!-- to do with neutrals -->
     <property name="neutralCharge" value="0"/>
     <property name="Neutrals Are Impassable" value="false" editable="false">
@@ -3810,6 +3773,7 @@
     <property name="Neutrals Are Blitzable" value="true" editable="false">
       <boolean/>
     </property>
+    
     <!-- Map Name: also used for map utils when asked -->
     <property name="mapName" value="red_sun_over_china" editable="false"/>
     <!-- notes appear in the notes menu in the main screen, format as html -->

--- a/map/games/Red_Sun_Over_China.xml
+++ b/map/games/Red_Sun_Over_China.xml
@@ -1834,14 +1834,12 @@
     </attachment>
     <attachment name="territoryAttachment" attachTo="Taiyuan" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
       <option name="production" value="4"/>
-      <option name="unitProduction" value="-4"/>
     </attachment>
     <attachment name="territoryAttachment" attachTo="Hong Kong" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
       <option name="production" value="4"/>
     </attachment>
     <attachment name="territoryAttachment" attachTo="Tsinan" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
       <option name="production" value="4"/>
-      <option name="unitProduction" value="-4"/>
     </attachment>
     <attachment name="territoryAttachment" attachTo="Yenan" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
       <option name="production" value="3"/>
@@ -1850,7 +1848,6 @@
     </attachment>
     <attachment name="territoryAttachment" attachTo="Canton" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
       <option name="production" value="6"/>
-      <option name="unitProduction" value="-4"/>
     </attachment>
     <attachment name="territoryAttachment" attachTo="Japan" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
       <option name="production" value="10"/>
@@ -1859,7 +1856,6 @@
     </attachment>
     <attachment name="territoryAttachment" attachTo="Nanchang" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
       <option name="production" value="4"/>
-      <option name="unitProduction" value="-4"/>
     </attachment>
     <attachment name="territoryAttachment" attachTo="Lanchow" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
       <option name="production" value="4"/>
@@ -1881,7 +1877,6 @@
     </attachment>
     <attachment name="territoryAttachment" attachTo="Wuhan" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
       <option name="production" value="6"/>
-      <option name="unitProduction" value="-4"/>
     </attachment>
     <attachment name="territoryAttachment" attachTo="Mukden" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
       <option name="production" value="6"/>
@@ -1901,27 +1896,21 @@
     </attachment>
     <attachment name="territoryAttachment" attachTo="Changsha" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
       <option name="production" value="4"/>
-      <option name="unitProduction" value="-4"/>
     </attachment>
     <attachment name="territoryAttachment" attachTo="Kunming" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
       <option name="production" value="6"/>
-      <option name="unitProduction" value="-4"/>
     </attachment>
     <attachment name="territoryAttachment" attachTo="Kweiyang" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
       <option name="production" value="4"/>
-      <option name="unitProduction" value="-4"/>
     </attachment>
     <attachment name="territoryAttachment" attachTo="Nanning" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
       <option name="production" value="4"/>
-      <option name="unitProduction" value="-4"/>
     </attachment>
     <attachment name="territoryAttachment" attachTo="Nanking" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
       <option name="production" value="4"/>
-      <option name="unitProduction" value="-4"/>
     </attachment>
     <attachment name="territoryAttachment" attachTo="Tsingtao" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
       <option name="production" value="4"/>
-      <option name="unitProduction" value="-4"/>
     </attachment>
     <attachment name="territoryAttachment" attachTo="Malaya-Singapore" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
       <option name="production" value="5"/>
@@ -3467,17 +3456,17 @@
       <unitPlacement unitType="cargo_train" territory="Lanchow Station" quantity="2" owner="Communist"/>
       <unitPlacement unitType="cargo_train" territory="Calcutta Station" quantity="2" owner="British"/>
       <unitPlacement unitType="armoured_train" territory="Calcutta Station" quantity="2" owner="British"/>
-      <unitPlacement unitType="factory" territory="Taiyuan" quantity="1" owner="Japanese"/>
-      <unitPlacement unitType="factory" territory="Nanking" quantity="1" owner="Nationalist"/>
-      <unitPlacement unitType="factory" territory="Tsinan" quantity="1" owner="Nationalist"/>
-      <unitPlacement unitType="factory" territory="Tsingtao" quantity="1" owner="Nationalist"/>
-      <unitPlacement unitType="factory" territory="Nanchang" quantity="1" owner="Nationalist"/>
-      <unitPlacement unitType="factory" territory="Wuhan" quantity="1" owner="Nationalist"/>
-      <unitPlacement unitType="factory" territory="Changsha" quantity="1" owner="Nationalist"/>
-      <unitPlacement unitType="factory" territory="Nanning" quantity="1" owner="Nationalist"/>
-      <unitPlacement unitType="factory" territory="Canton" quantity="1" owner="Nationalist"/>
-      <unitPlacement unitType="factory" territory="Kweiyang" quantity="1" owner="Nationalist"/>
-      <unitPlacement unitType="factory" territory="Kunming" quantity="1" owner="Nationalist"/>
+      <unitPlacement unitType="factory" territory="Taiyuan" quantity="1" owner="Japanese" unitDamage="8"/>
+      <unitPlacement unitType="factory" territory="Nanking" quantity="1" owner="Nationalist" unitDamage="8"/>
+      <unitPlacement unitType="factory" territory="Tsinan" quantity="1" owner="Nationalist" unitDamage="8"/>
+      <unitPlacement unitType="factory" territory="Tsingtao" quantity="1" owner="Nationalist" unitDamage="8"/>
+      <unitPlacement unitType="factory" territory="Nanchang" quantity="1" owner="Nationalist" unitDamage="8"/>
+      <unitPlacement unitType="factory" territory="Wuhan" quantity="1" owner="Nationalist" unitDamage="10"/>
+      <unitPlacement unitType="factory" territory="Changsha" quantity="1" owner="Nationalist" unitDamage="8"/>
+      <unitPlacement unitType="factory" territory="Nanning" quantity="1" owner="Nationalist" unitDamage="8"/>
+      <unitPlacement unitType="factory" territory="Canton" quantity="1" owner="Nationalist" unitDamage="10"/>
+      <unitPlacement unitType="factory" territory="Kweiyang" quantity="1" owner="Nationalist" unitDamage="8"/>
+      <unitPlacement unitType="factory" territory="Kunming" quantity="1" owner="Nationalist" unitDamage="10"/>
       <unitPlacement unitType="ruralproduction" territory="Poseh" quantity="1" owner="Nationalist"/>
       <unitPlacement unitType="ruralproduction" territory="Swatow" quantity="1" owner="Nationalist"/>
       <unitPlacement unitType="ruralproduction" territory="Huaipei" quantity="1" owner="Nationalist"/>
@@ -3720,9 +3709,7 @@
     <property name="Unplaced units live when not placed" value="true" editable="false">
       <boolean/>
     </property>
-    <property name="Occupied Territories" value="true" editable="false">
-      <boolean/>
-    </property>
+
     <!-- specific rules -->
     <!-- land related -->
     <property name="Blitz Through Factories And AA Restricted" value="false" editable="false">

--- a/map/games/Red_Sun_Over_China.xml
+++ b/map/games/Red_Sun_Over_China.xml
@@ -2872,7 +2872,7 @@
     <!-- Communist Quarantine -->
     <attachment name="objectiveAttachment10" attachTo="Communist" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
       <option name="objectiveValue" value="5"/>
-      <option name="alliedExclusionTerritories" value="original"/>
+      <option name="alliedExclusionTerritories" value="Yenan:Fen-chow:Puchow:Sian:Weinan:Ankang:Hanchung:Tsingyang:Kungchangfu:Kuyuan:Lanchow"/>
     </attachment>
     <!-- British  Objectives -->
     <!-- Colonial Strongholds -->


### PR DESCRIPTION
https://forums.triplea-game.org/topic/947/red-sun-over-china-possible-bugs

- nationalists cant build in their factories (except the capital)
- nationalist factories are supposed to start damaged and require a premium to repair but this isn't functioning; neither the nationalists nor japan (after capture) can repair/use them
- nationalists can build in the countryside but japan can "damage" the countryside with strat bombing, which is probably not intended
- 2 hit battleships fail to repair
- communists seem to get "no allies in my territory" bonus regardless of where allies are