### PR TITLE
Fixes part 2

### DIFF
--- a/map/games/Red_Sun_Over_China.xml
+++ b/map/games/Red_Sun_Over_China.xml
@@ -2961,16 +2961,6 @@
       <option name="placementAnyTerritory" value="false"/>
       <option name="placementCapturedTerritory" value="true"/>
     </attachment>
-    <!--
-				<attachment name="rulesAttachment" attachTo="Communist" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="movementRestrictionTerritories" value="Chungking:Chengang:Hong Kong:Fen-chow:Sog-rigs:Swatow:Huaipei:Tsingyang:Ichow:Fengdu:East Sikang:Chih-Chiang:Hangchow:Hanchung:Tientsin:Jih-Chao:Techow:Tsinan:Tuyun:Chenyuan:Kweiyang:Yen-ping:Weinan:Suifu:Kunming:Tsangchow:Tsingtai:Udon Thani:Juning:Tsingtao:North Jehol:Huainan:Anyang:Hwangshi:Tali:Kweilin:Yenan:Chien-ning:Ningyen:Ningsia:Hsingi:Ankang:Cheng-tu:Taiyuan:Liaocheng:Chiu-Chuan:Liaodong:Chengteh:Puchow:Kuyuan:Kannan:Kungchangfu:Huangshan:Shanhaiguan:Weihsien:Canton:Lungkow:Pa-chung:Nanning:Ordos Plateau:Anking:Changteh:Amoy:Kining:Poseh:Tsinghai:Kaifeng:West Kwangtung:Puel:Luan:Nanchang:Paoting:Wuhu:Nanyang:Soochow:Pinghsiang:Kirin:Lanchow:Shanghai:Wu Tang Mountains:Lu-ting:Chahar:Weihaiwei:Momein:Port Arthur:Wuhan:Kan:Mukden:Fancheng:Tungting:Ichang:Golog:Sian:Tangshan:Bichieh:Kutsing:Nanking:Mengtsi:Hsuchow:Sining:Shiuchow:Hehsi Corridor:Woochow:Szecheng:Peking:Chenchow:Luoyang:North Suiyuan:Ningpo:So-ping:Hwanggang:Yang-chow:Siangtan:Luchow:Foochow:Kunlun Mountains:Changchih:Chin-kiang:Poyang:Te-king:Lungchow:Changsha"/>
-                	<option name="movementRestrictionType" value="allowed"/>
-					<option name="unlimitedProduction" value="true"/>
-                	<option name="placementAnyTerritory" value="true"/>
-                	<option name="placementCapturedTerritory" value="true"/>
-                	<option name="placementPerTerritory" value="1000"/>
-                </attachment>
--->
     <attachment name="rulesAttachment" attachTo="Nationalist" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
       <option name="movementRestrictionTerritories" value="Chiang Mai:Kra:Bangkok:Phitsanulok:Nakhon Sawan:Udon Thani:Cambodia:Cochinchina:Annam:South Laos:Luang Prabang:Tonkin:Hanoi"/>
       <option name="movementRestrictionType" value="disallowed"/>
@@ -2978,16 +2968,21 @@
       <option name="placementAnyTerritory" value="false"/>
       <option name="placementCapturedTerritory" value="true"/>
     </attachment>
-    <!--
-				<attachment name="rulesAttachment" attachTo="Nationalist" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="movementRestrictionTerritories" value="Chungking:Chengang:Hong Kong:Fen-chow:Sog-rigs:Swatow:Huaipei:Tsingyang:Ichow:Fengdu:East Sikang:Chih-Chiang:Hangchow:Hanchung:Tientsin:Jih-Chao:Techow:Tsinan:Tuyun:Chenyuan:Kweiyang:Yen-ping:Weinan:Suifu:Kunming:Tsangchow:Tsingtai:Udon Thani:Juning:Tsingtao:North Jehol:Huainan:Anyang:Hwangshi:Tali:Kweilin:Yenan:Chien-ning:Ningyen:Ningsia:Hsingi:Ankang:Cheng-tu:Taiyuan:Liaocheng:Chiu-Chuan:Liaodong:Chengteh:Puchow:Kuyuan:Kannan:Kungchangfu:Huangshan:Shanhaiguan:Weihsien:Canton:Lungkow:Pa-chung:Nanning:Ordos Plateau:Anking:Changteh:Amoy:Kining:Poseh:Tsinghai:Kaifeng:West Kwangtung:Puel:Luan:Nanchang:Paoting:Wuhu:Nanyang:Soochow:Pinghsiang:Kirin:Lanchow:Shanghai:Wu Tang Mountains:Lu-ting:Chahar:Weihaiwei:Momein:Port Arthur:Wuhan:Kan:Mukden:Fancheng:Tungting:Ichang:Golog:Sian:Tangshan:Bichieh:Kutsing:Nanking:Mengtsi:Hsuchow:Sining:Shiuchow:Hehsi Corridor:Woochow:Szecheng:Peking:Chenchow:Luoyang:North Suiyuan:Ningpo:So-ping:Hwanggang:Yang-chow:Siangtan:Luchow:Foochow:Kunlun Mountains:Changchih:Chin-kiang:Poyang:Te-king:Lungchow:Changsha:Kentung:Taungoo:Rangoon:Pathein:Chin:Sittang:Lashio:Mandalay:Chindwin:Myitkyina:SZ 3 North Yellow Sea:SZ 7 East China Sea:SZ 14 South China Sea:SZ 5 Sea of Japan:SZ 6 East China Sea:SZ 9 Taiwan Strait:SZ 16 Gulf of Thailand:SZ 19 Bay of Bengal:SZ 8 East China Sea:SZ 15 Philippine Sea:SZ 12 Gulf of Tonkin:SZ 1 Bohai Bay:SZ 17 Malay Sea:SZ 20 Indian Ocean:SZ 11 Philippine Sea:SZ 2 Bohai Sea:SZ 4 South Yellow Sea:SZ 13 South China Sea:SZ 18 Andaman Sea:SZ 10 South China Sea:SZ 21 Strait of Malacca"/>
-                	<option name="movementRestrictionType" value="allowed"/>
-					<option name="unlimitedProduction" value="true"/>
-                	<option name="placementAnyTerritory" value="true"/>
-                	<option name="placementCapturedTerritory" value="false"/>
-                	<option name="placementPerTerritory" value="1000"/>
-                </attachment>
--->
+    <attachment name="conditionAttachmentAlways" attachTo="Nationalist" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+      <option name="switch" value="true"/>
+    </attachment>
+    <attachment name="triggerAttachmentNationalistUnitsRequireFactoryOn" attachTo="Nationalist" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+      <option name="conditions" value="conditionAttachmentAlways"/>
+      <option name="unitType" value="elite:heavy_artillery:light_artillery:armour:fighter:aaGun:cargo_train:armoured_train:bomber"/>
+      <option name="unitProperty" value="requiresUnits" count="factory"/>
+      <option name="when" value="before:nationalistCombatMove"/>
+    </attachment>
+    <attachment name="triggerAttachmentNationalistUnitsRequireFactoryOff" attachTo="Nationalist" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+      <option name="conditions" value="conditionAttachmentAlways"/>
+      <option name="unitType" value="elite:heavy_artillery:light_artillery:armour:fighter:aaGun:cargo_train:armoured_train:bomber"/>
+      <option name="unitProperty" value="requiresUnits" count="-reset-"/>
+      <option name="when" value="after:nationalistEndTurn"/>
+    </attachment>
   </attachmentList>
   <initialize>
     <ownerInitialize>
@@ -3628,6 +3623,9 @@
     <property name="National Objectives" value="true" editable="true">
       <boolean/>
     </property>
+    <property name="Use Triggers" value="true" editable="false">
+      <boolean/>
+    </property>
     <property name="Always on AA" value="true" editable="true">
       <boolean/>
     </property>
@@ -3759,6 +3757,9 @@
     </property>
     <property name="maxFactoriesPerTerritory" value="100"/>
     <property name="Placement Restricted By Factory" value="true" editable="false">
+      <boolean/>
+    </property>
+    <property name="Unit Placement Restrictions" value="true" editable="false">
       <boolean/>
     </property>
     <property name="Damage From Bombing Done To Units Instead Of Territories" value="true" editable="false">

--- a/map/games/Red_Sun_Over_China.xml
+++ b/map/games/Red_Sun_Over_China.xml
@@ -1103,7 +1103,7 @@
       <!-- Manchukwo Game Sequence -->
       <!--<step name="manchukwoTech" delegate="tech" player="Manchukwo"/>
                         <step name="manchukwoTechActivation" delegate="tech_activation" player="Manchukwo"/>-->
-      <step name="mManchukwoCombatMove" delegate="move" player="Manchukwo"/>
+      <step name="manchukwoCombatMove" delegate="move" player="Manchukwo"/>
       <step name="manchukwoPurchase" delegate="purchase" player="Manchukwo"/>
       <step name="manchukwoBattle" delegate="battle" player="Manchukwo"/>
       <step name="manchukwoNonCombatMove" delegate="move" player="Manchukwo" display="Non Combat Move"/>
@@ -2968,6 +2968,7 @@
       <option name="placementAnyTerritory" value="false"/>
       <option name="placementCapturedTerritory" value="true"/>
     </attachment>
+    <!--  Triggers For Units Requiring Factories -->
     <attachment name="conditionAttachmentAlways" attachTo="Nationalist" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
       <option name="switch" value="true"/>
     </attachment>
@@ -2982,6 +2983,42 @@
       <option name="unitType" value="elite:heavy_artillery:light_artillery:armour:fighter:aaGun:cargo_train:armoured_train:bomber"/>
       <option name="unitProperty" value="requiresUnits" count="-reset-"/>
       <option name="when" value="after:nationalistEndTurn"/>
+    </attachment>
+    <attachment name="triggerAttachmentManchukwoUnitsRequireFactoryOn" attachTo="Manchukwo" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+      <option name="conditions" value="conditionAttachmentAlways"/>
+      <option name="unitType" value="infantry:light_infantry:cavalry:heavy_cavalry:light_artillery:aaGun:cargo_train:armoured_train"/>
+      <option name="unitProperty" value="requiresUnits" count="factory"/>
+      <option name="when" value="before:manchukwoCombatMove"/>
+    </attachment>
+    <attachment name="triggerAttachmentManchukwoUnitsRequireFactoryOff" attachTo="Manchukwo" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+      <option name="conditions" value="conditionAttachmentAlways"/>
+      <option name="unitType" value="infantry:light_infantry:cavalry:heavy_cavalry:light_artillery:aaGun:cargo_train:armoured_train"/>
+      <option name="unitProperty" value="requiresUnits" count="-reset-"/>
+      <option name="when" value="after:manchukwoEndTurn"/>
+    </attachment>
+    <attachment name="triggerAttachmentJapaneseUnitsRequireFactoryOn" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+      <option name="conditions" value="conditionAttachmentAlways"/>
+      <option name="unitType" value="infantry:elite:mobile_infantry:heavy_artillery:light_artillery:armour:light_armour:fighter:bomber:transport:submarine:carrier:destroyer:cruiser:battleship:aaGun:cargo_train:armoured_train"/>
+      <option name="unitProperty" value="requiresUnits" count="factory"/>
+      <option name="when" value="before:japanesePlace"/>
+    </attachment>
+    <attachment name="triggerAttachmentJapaneseUnitsRequireFactoryOff" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+      <option name="conditions" value="conditionAttachmentAlways"/>
+      <option name="unitType" value="infantry:elite:mobile_infantry:heavy_artillery:light_artillery:armour:light_armour:fighter:bomber:transport:submarine:carrier:destroyer:cruiser:battleship:aaGun:cargo_train:armoured_train"/>
+      <option name="unitProperty" value="requiresUnits" count="-reset-"/>
+      <option name="when" value="after:japanesePlace"/>
+    </attachment>
+    <attachment name="triggerAttachmentBritishUnitsRequireFactoryOn" attachTo="British" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+      <option name="conditions" value="conditionAttachmentAlways"/>
+      <option name="unitType" value="infantry:commando:heavy_artillery:light_artillery:armour:fighter:bomber:transport:submarine:carrier:destroyer:cruiser:battleship:aaGun:cargo_train:armoured_train"/>
+      <option name="unitProperty" value="requiresUnits" count="factory"/>
+      <option name="when" value="before:britishCombatMove"/>
+    </attachment>
+    <attachment name="triggerAttachmentBritishUnitsRequireFactoryOff" attachTo="British" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+      <option name="conditions" value="conditionAttachmentAlways"/>
+      <option name="unitType" value="infantry:commando:heavy_artillery:light_artillery:armour:fighter:bomber:transport:submarine:carrier:destroyer:cruiser:battleship:aaGun:cargo_train:armoured_train"/>
+      <option name="unitProperty" value="requiresUnits" count="-reset-"/>
+      <option name="when" value="after:britishEndTurn"/>
     </attachment>
   </attachmentList>
   <initialize>
@@ -3784,8 +3821,8 @@
 						<CENTER>
 <b><font size="6">Red Sun Over China: The Second Sino-Japanese War</font></b> <br>
 						<br>
-						by Pulicat <br></CENTER> <br>
-						Version 2.3 <br>
+						by Pulicat <br>
+						Version 2.3 <br></CENTER>
 						<p><br>
 						  Credits: Pulicat (creator and map design), erik542 (balance and playtesting), Veqryn (troubleshooting and general awesomeness). Thanks to all players and testers such as lalapalooza and everybody else!<br>
 						  <br>
@@ -3795,9 +3832,8 @@
 </p>
   <p><b>SPECIAL REMINDERS:</b></p>
 <p><b>1) Movement from one side of an enemy city to another is technically possible, but is considered ILLEGAL.</b></p>
-  <p><strong>2) Manchukwo, Japanese, and British may build ONLY in FACTORIES.</strong>  </p>
-  <p><strong>3) British are not allowed to fight Axis for the first 3 rounds (Phase I), unless any Axis country attacks it first.</strong>  </p>
-  <p><b>The rules listed in the special reminder above are unique to this mod, but unfortunately TripleA cannot code for their automatic implementation. TripleA will not automatically enforce the rule and you must keep the rules in mind yourself and take care to not violate the rules.</b></p><br>
+  <p><strong>2) British are not allowed to fight Axis for the first 3 rounds (Phase I), unless any Axis country attacks it first.</strong>  </p>
+  <p><b>The rules listed in the special reminder above are unique to this mod. TripleA will not automatically enforce the rule and you must keep the rules in mind yourself and take care to not violate the rules.</b></p><br>
     <br>
     <a name="Countries"><font size="5"><b><em>Countries</em></b></font></a>
 						<br><b>Axis Powers</b><br />
@@ -3805,13 +3841,13 @@
 						<li>Japan (capital: Japan)</li>
 						<li>Manchukwo (capital: Mukden)</li>
 						<li>Thailand (capital: Bangkok)</li>
-						</UL> <br />
+						</ul>
 						<br><b>Allied Powers</b><br />
 						  <ul>
 						<li>Nationalist (capital: Chungking)</li>
 						<li>Communist (no capital, the flag in the map is merely decoration)</li>
 						<li>British (capital: Calcutta)</li>
-						</UL> <br />
+						</ul>
   <br />
 
     <p><a name="Movement"><font size="5"><b><em>Movement</em></b></font></a></p>
@@ -3865,8 +3901,9 @@ Defeat Colonial Strongholds: <br />
 (+5) Axis controls Hong Kong.<br />
 (+5) Axis controls Rangoon.<br />
 (+5) Axis controls Mandalay.<br />
+<br />
 <i>Thailand--</i><br />
-(+10) Territorial Intergrity: Axis controls Kra, Bangkok, Chiang Mai, Nakhon Sawan, Phitsanulok, and Udon Thani.<br />
+(+10) Territorial Integrity: Axis controls Kra, Bangkok, Chiang Mai, Nakhon Sawan, Phitsanulok, and Udon Thani.<br />
 (+10) Indochinese resources: Thailand also gets 10 PU if Axis controls Luang Prabang, South Laos, Cambodia, Cochinchina, Annam, Tonkin, and Hanoi.<br>
 </p>
 <br>


### PR DESCRIPTION
Part 2 of https://forums.triplea-game.org/topic/947/red-sun-over-china-possible-bugs
- nationalists are supposed to only be able to make infantry and cavalry in the countryside but the engine allows anything to be built
- TripleA now enforces "Manchukwo, Japanese, and British may build ONLY in FACTORIES."